### PR TITLE
Set GOOS and GOARCH fix.

### DIFF
--- a/tasks/grunt-go.js
+++ b/tasks/grunt-go.js
@@ -228,12 +228,12 @@ module.exports = function (grunt) {
           .concat(createPath(gruntTaskTargetOpts))
           .concat(createPath(gruntTaskTargetProfileOpts)).join(getOSMultilineVarSeparator());
 
-      var goos = grunt.option('GOOS');
+      var goos = gruntTaskOpts["GOOS"];
       if (goos) {
         cmdOpts['env'].GOOS = goos;
       }
 
-      var goarch = grunt.option('GOARCH');
+      var goarch = gruntTaskOpts["GOARCH"];
       if (goarch) {
         cmdOpts['env'].GOARCH = goarch;
       }


### PR DESCRIPTION
Was unable to set GOOS and GOARCH options using this:

``` js
go: {
        options: {
                GOPATH: [ "D:/go" ],
                GOOS: 'linux',
                GOARCH: 'amd64'
        },
        ...
}
```

`grunt.option('GOOS')` and `grunt.option('GOARCH')` were returning `undefined`
Changing these calls to `gruntTaskOpts["GOOS"]` and `gruntTaskOpts["GOARCH"]` solved the problem for me.
