### PR TITLE
Fix handling of absolute paths for GOPATH

### DIFF
--- a/tasks/grunt-go.js
+++ b/tasks/grunt-go.js
@@ -79,7 +79,11 @@ module.exports = function (grunt) {
 
     if (paths) {
       for (var i in paths) {
-        res.push(path.resolve(path.join(root, paths[i])));
+        if (paths[i][0] != '/') {
+          res.push(path.resolve(path.join(root, paths[i])));
+        } else {
+          res.push(path.resolve(paths[i]));
+        }
       }
     }
 

--- a/tasks/grunt-go.js
+++ b/tasks/grunt-go.js
@@ -244,6 +244,7 @@ module.exports = function (grunt) {
       // ==== execute and return
 
       var fullCmd = cmd + ' ' + cmdArgs.join(' ');
+      grunt.log.writeln('WARNING: forked repo');
       grunt.log.writeln('executing: ' + fullCmd);
 
       if (dryRun !== true) {

--- a/tasks/grunt-go.js
+++ b/tasks/grunt-go.js
@@ -248,7 +248,6 @@ module.exports = function (grunt) {
       // ==== execute and return
 
       var fullCmd = cmd + ' ' + cmdArgs.join(' ');
-      grunt.log.writeln('WARNING: forked repo');
       grunt.log.writeln('executing: ' + fullCmd);
 
       if (dryRun !== true) {


### PR DESCRIPTION
There are cases where you might want to specify a 'root' but use the system wide GOPATH. This is problematic when GOPATH is not underneath root e.g.

root: /Users/someuser/workspace/project1/src/
process.env.GOPATH: /Users/someuser/workspace

Here, you could make it work with GOPATH: ['../..'], but this becomes machine/environment specific. This doesn't work with travis-ci for example.

A better solution is to allow absolute paths. Then GOPATH: [process.env.GOPATH] works equally well as long as it's an absolute path.
